### PR TITLE
Fix OsmId and PlaceId data types

### DIFF
--- a/nominatim_reverse_test.go
+++ b/nominatim_reverse_test.go
@@ -27,7 +27,7 @@ import (
 
 func Test_CreateReverseQuery(t *testing.T) {
 	defer SetServer("")
-	SetServer("http://nominatim.openstreetmap.org")
+	SetServer("https://nominatim.openstreetmap.org")
 	rqry := new(ReverseQuery)
 	rqry.Lat = "52.5170365"
 	rqry.Lon = "13.3888599"
@@ -53,7 +53,7 @@ func Test_ReverseQueryWithoutServer(t *testing.T) {
 
 func Test_OSMType(t *testing.T) {
 	defer SetServer("")
-	SetServer("http://nominatim.openstreetmap.org")
+	SetServer("https://nominatim.openstreetmap.org")
 	rqry := new(ReverseQuery)
 	rqry.Lat = "52.5170365"
 	rqry.Lon = "13.3888599"
@@ -79,7 +79,7 @@ func Test_OSMType(t *testing.T) {
 
 func Test_LatLon(t *testing.T) {
 	defer SetServer("")
-	SetServer("http://nominatim.openstreetmap.org")
+	SetServer("https://nominatim.openstreetmap.org")
 	rqry := new(ReverseQuery)
 	rqry.Lon = "13.3888599"
 	_, err := rqry.buildQuery()
@@ -105,7 +105,7 @@ func Test_LatLon(t *testing.T) {
 
 func Test_Zoom(t *testing.T) {
 	defer SetServer("")
-	SetServer("http://nominatim.openstreetmap.org")
+	SetServer("https://nominatim.openstreetmap.org")
 	rqry := new(ReverseQuery)
 	rqry.Lon = "13.3888599"
 	rqry.Lat = "52.5170365"

--- a/nominatim_search.go
+++ b/nominatim_search.go
@@ -34,10 +34,10 @@ type searchResultError struct {
 }
 
 type SearchResult struct {
-	PlaceId       string     `json:"place_id"`
+	PlaceId       int        `json:"place_id"`
 	License       string     `json:"license"`
 	OsmType       string     `json:"osm_type"`
-	OsmId         string     `json:"osm_id"`
+	OsmId         int        `json:"osm_id"`
 	Boundingbox   []string   `json:"boundingbox"`
 	Polygonpoints [][]string `json:"polygonpoints"`
 	Lat           string     `json:"lat"`

--- a/nominatim_search_test.go
+++ b/nominatim_search_test.go
@@ -28,7 +28,7 @@ import (
 
 func Test_CreateSearchQuery(t *testing.T) {
 	defer SetServer("")
-	SetServer("http://nominatim.openstreetmap.org")
+	SetServer("https://nominatim.openstreetmap.org")
 	expectation := "q=Berlin"
 	q := new(SearchQuery)
 	q.Q = "Berlin"
@@ -43,7 +43,7 @@ func Test_CreateSearchQuery(t *testing.T) {
 
 func Test_CreateSearchQueryWithParams(t *testing.T) {
 	defer SetServer("")
-	SetServer("http://nominatim.openstreetmap.org")
+	SetServer("https://nominatim.openstreetmap.org")
 	expectations := []string{
 		"city=Berlin",
 		"street=Karl-Marx-Allee",
@@ -71,7 +71,7 @@ func Test_CreateSearchQueryWithParams(t *testing.T) {
 
 func Test_SpecificFieldsUsed(t *testing.T) {
 	defer SetServer("")
-	SetServer("http://nominatim.openstreetmap.org")
+	SetServer("https://nominatim.openstreetmap.org")
 	q1 := &SearchQuery{
 		City:       "Berlin",
 		Street:     "Karl-Marx-Allee",
@@ -91,7 +91,7 @@ func Test_SpecificFieldsUsed(t *testing.T) {
 
 func Test_EmptySearchQuery(t *testing.T) {
 	defer SetServer("")
-	SetServer("http://nominatim.openstreetmap.org")
+	SetServer("https://nominatim.openstreetmap.org")
 	q := new(SearchQuery)
 	_, err := q.buildQuery()
 	if err == nil {
@@ -101,7 +101,7 @@ func Test_EmptySearchQuery(t *testing.T) {
 
 func Test_DoubleSearchQuery(t *testing.T) {
 	defer SetServer("")
-	SetServer("http://nominatim.openstreetmap.org")
+	SetServer("https://nominatim.openstreetmap.org")
 	q := &SearchQuery{
 		City:       "Berlin",
 		Street:     "Karl-Marx-Allee",
@@ -133,7 +133,7 @@ func Test_DoubleSearchQuery(t *testing.T) {
 
 func Test_LimitedSearchQuery(t *testing.T) {
 	defer SetServer("")
-	SetServer("http://nominatim.openstreetmap.org")
+	SetServer("https://nominatim.openstreetmap.org")
 	expectation := "limit=123"
 	q := new(SearchQuery)
 	q.Q = "Berlin"
@@ -149,7 +149,7 @@ func Test_LimitedSearchQuery(t *testing.T) {
 
 func Test_AddressFields(t *testing.T) {
 	defer SetServer("")
-	SetServer("http://nominatim.openstreetmap.org")
+	SetServer("https://nominatim.openstreetmap.org")
 	q := new(SearchQuery)
 	q.Q = "Unter den Linden"
 	resp, err := q.Get()


### PR DESCRIPTION
Looks like integers are returned nowadays.

```
➜  gominatim git:(master) go test -v
=== RUN   Test_CreateReverseQuery
--- PASS: Test_CreateReverseQuery (0.00s)
=== RUN   Test_ReverseQueryWithoutServer
--- PASS: Test_ReverseQueryWithoutServer (0.00s)
=== RUN   Test_OSMType
--- PASS: Test_OSMType (0.00s)
=== RUN   Test_LatLon
--- PASS: Test_LatLon (0.00s)
=== RUN   Test_Zoom
--- PASS: Test_Zoom (0.00s)
=== RUN   Test_CreateSearchQuery
--- PASS: Test_CreateSearchQuery (0.00s)
=== RUN   Test_CreateSearchQueryWithParams
--- PASS: Test_CreateSearchQueryWithParams (0.00s)
=== RUN   Test_SpecificFieldsUsed
--- PASS: Test_SpecificFieldsUsed (0.00s)
=== RUN   Test_EmptySearchQuery
--- PASS: Test_EmptySearchQuery (0.00s)
=== RUN   Test_DoubleSearchQuery
--- PASS: Test_DoubleSearchQuery (0.00s)
=== RUN   Test_LimitedSearchQuery
--- PASS: Test_LimitedSearchQuery (0.00s)
=== RUN   Test_AddressFields
--- FAIL: Test_AddressFields (0.42s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 30 [running]:
testing.tRunner.func1.1(0x722b40, 0xc00024e1c0)
	/usr/local/go/src/testing/testing.go:941 +0x3d0
testing.tRunner.func1(0xc0000d10e0)
	/usr/local/go/src/testing/testing.go:944 +0x3f9
panic(0x722b40, 0xc00024e1c0)
	/usr/local/go/src/runtime/panic.go:967 +0x15d
_/home/rubiojr/git/muesli/gominatim.Test_AddressFields(0xc0000d10e0)
	/home/rubiojr/git/muesli/gominatim/nominatim_search_test.go:156 +0x3cc
testing.tRunner(0xc0000d10e0, 0x75e1d0)
	/usr/local/go/src/testing/testing.go:992 +0xdc
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1043 +0x357
exit status 2
FAIL	_/home/rubiojr/git/muesli/gominatim	0.428s
```