### PR TITLE
Use 64 bits integers for OSM ID and Place ID

### DIFF
--- a/nominatim_reverse.go
+++ b/nominatim_reverse.go
@@ -35,10 +35,10 @@ type reverseAPIResult struct {
 }
 
 type ReverseResult struct {
-	PlaceId     int     `json:"place_id"`
+	PlaceId     int64   `json:"place_id"`
 	License     string  `json:"license"`
 	OsmType     string  `json:"osm_type"`
-	OsmId       int     `json:"osm_id"`
+	OsmId       int64   `json:"osm_id"`
 	Lat         string  `json:"lat"`
 	Lon         string  `json:"lon"`
 	DisplayName string  `json:"display_name"`

--- a/nominatim_search.go
+++ b/nominatim_search.go
@@ -34,10 +34,10 @@ type searchResultError struct {
 }
 
 type SearchResult struct {
-	PlaceId       int        `json:"place_id"`
+	PlaceId       int64      `json:"place_id"`
 	License       string     `json:"license"`
 	OsmType       string     `json:"osm_type"`
-	OsmId         int        `json:"osm_id"`
+	OsmId         int64      `json:"osm_id"`
 	Boundingbox   []string   `json:"boundingbox"`
 	Polygonpoints [][]string `json:"polygonpoints"`
 	Lat           string     `json:"lat"`


### PR DESCRIPTION
int is not large enough on 32 bits architectures.

This is the result of running this simple test on a raspberry pi:

```
package main

import "github.com/muesli/gominatim"

func main() {
	gominatim.SetServer("https://nominatim.openstreetmap.org/")
	qry := gominatim.SearchQuery{
		Q: "barcelona",
	}
	_, err := qry.Get()
	if err != nil {
panic(err)
	}

}
```

go run test.go yields:

```
json: cannot unmarshal number 5847348785 into Go struct field SearchResult.osm_id of type int
```

This has the unfortunate side effect of breaking backwards compat but I don't think we have other options here, unless we want to add a `v2` package.