### PR TITLE
Refactored to add a custom user-agent in order to avoid server blockade

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/muesli/gominatim"
+	"github.com/xiconet/gominatim"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/muesli/gominatim/badge.svg?branch=master)](https://coveralls.io/github/muesli/gominatim?branch=master)
 [![Go ReportCard](http://goreportcard.com/badge/muesli/gominatim)](http://goreportcard.com/report/muesli/gominatim)
 
-## Geocoding? WTF?
+## Geocoding? 
 
 If you want to determine the coordinates of a certain location by only having its
 name, you can do this via a geocoding service. If you want to do this in Go, you

--- a/example/example.go
+++ b/example/example.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/muesli/gominatim"
+	"github.com/xiconet/gominatim"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/muesli/gominatim
+module github.com/xiconet/gominatim
 
 go 1.14

--- a/nominatim_reverse.go
+++ b/nominatim_reverse.go
@@ -116,13 +116,11 @@ func (r *ReverseQuery) Get() (*ReverseResult, error) {
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
-	if resp.StatusCode > 299 {
-		log.Fatalf("Response failed with status code: %d and\nbody: %s\n", resp.StatusCode, body)
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode > 299 {
+		log.Fatalf("Response failed with status code: %d and\nbody: %s\n", resp.StatusCode, body)
 	}
 	result := new(reverseAPIResult)
 	err = json.Unmarshal(body, &result)

--- a/nominatim_reverse.go
+++ b/nominatim_reverse.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -103,9 +104,20 @@ func (r *ReverseQuery) Get() (*ReverseResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.Get(querystring)
+	req, err := http.NewRequest("GET", querystring, nil)
 	if err != nil {
 		return nil, err
+	}
+	req.Header.Set("User-Agent", user_agent)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Println("error while fetching", querystring) 
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode > 299 {
+		log.Fatalf("Response failed with status code: %d and\nbody: %s\n", resp.StatusCode, body)
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)

--- a/nominatim_search.go
+++ b/nominatim_search.go
@@ -198,10 +198,10 @@ func (q *SearchQuery) Get() ([]SearchResult, error) {
 		return nil, err
 	}
 	req, err := http.NewRequest("GET", querystring, nil)
-	req.Header.Set("User-Agent", user_agent)
 	if err != nil {
 		panic(err)
 	}
+	req.Header.Set("User-Agent", user_agent)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		fmt.Println("error while fetching", querystring) 

--- a/nominatim_search.go
+++ b/nominatim_search.go
@@ -30,11 +30,11 @@ import (
 	"fmt"
 	"log"
 )
-
+const user_agent = "some_user_agent_of_your_choice"
 type searchResultError struct {
 	error string `json:"error"`
 }
-
+ 
 type SearchResult struct {
 	PlaceId       int64      `json:"place_id"`
 	License       string     `json:"license"`

--- a/nominatim_search.go
+++ b/nominatim_search.go
@@ -27,6 +27,8 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"fmt"
+	"log"
 )
 
 type searchResultError struct {
@@ -195,12 +197,21 @@ func (q *SearchQuery) Get() ([]SearchResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.Get(querystring)
+	req, err := http.NewRequest("GET", querystring, nil)
+	req.Header.Set("User-Agent", user_agent)
 	if err != nil {
+		panic(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		fmt.Println("error while fetching", querystring) 
 		return nil, err
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode > 299 {
+		log.Fatalf("Response failed with status code: %d and\nbody: %s\n", resp.StatusCode, body)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use `http.NewRequest() `and `http:DefaulltClient.Do()` to set some custom user-agent. The osm api will frequently block requests when using http.Get().